### PR TITLE
use effective date in bylines and for sorting, refs #5

### DIFF
--- a/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
@@ -18,8 +18,10 @@
                              navigation_root_url context/@@plone_portal_state/navigation_root_url;
                              pas_member context/@@pas_member;
                              item_creator context/Creator;
+                             item_created context/CreationDate;
                              item_type context/portal_type;
                              item_effective context/EffectiveDate;
+                             item_display_date python: item_effective != 'None' and item_effective or item_created;
                              item_url context/getURL|context/absolute_url;
                              show_border context/@@plone/showEditableBorder;
                              show_border python:show_border and not ajax_load">
@@ -65,7 +67,7 @@
                tal:content="author/name_or_id">
                   Bob Dobalina
             </a>
-            <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
+            <date tal:content="python: toLocalizedTime(item_display_date,long_format=1)">Date</date>
           </div>
         </hgroup>
 

--- a/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
@@ -19,7 +19,7 @@
                              pas_member context/@@pas_member;
                              item_creator context/Creator;
                              item_type context/portal_type;
-                             item_modified context/ModificationDate;
+                             item_effective context/EffectiveDate;
                              item_url context/getURL|context/absolute_url;
                              show_border context/@@plone/showEditableBorder;
                              show_border python:show_border and not ajax_load">
@@ -65,7 +65,7 @@
                tal:content="author/name_or_id">
                   Bob Dobalina
             </a>
-            <date tal:content="python: toLocalizedTime(item_modified,long_format=1)">Date</date>
+            <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
           </div>
         </hgroup>
 

--- a/src/lmu/contenttypes/blog/browser/templates/frontpage_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/frontpage_view.pt
@@ -89,7 +89,7 @@
         <tal:entry tal:define="item entry/getObject;
                                item_creator entry/Creator;
                                item_type entry/portal_type;
-                               item_modified entry/ModificationDate;
+                               item_effective entry/EffectiveDate;
                                item_url item/getURL|item/absolute_url;">
         <article class="blog-entry blog-preview clearfix" 
                  tal:define="text python:view.strip_text(item);
@@ -141,7 +141,7 @@
                  tal:omit-tag="not:author">
                 Bob Dobalina
               </a> 
-              <date tal:content="python: toLocalizedTime(item_modified,long_format=1)">Date</date>
+              <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
             </div>
           </hgroup>
           <p tal:content="text">Blog Entry Text</p>

--- a/src/lmu/contenttypes/blog/browser/templates/frontpage_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/frontpage_view.pt
@@ -88,8 +88,10 @@
         <tal:block tal:repeat="entry view/entries">
         <tal:entry tal:define="item entry/getObject;
                                item_creator entry/Creator;
+                               item_created entry/CreationDate;
                                item_type entry/portal_type;
                                item_effective entry/EffectiveDate;
+                               item_display_date python: item_effective != 'None' and item_effective or item_created;
                                item_url item/getURL|item/absolute_url;">
         <article class="blog-entry blog-preview clearfix" 
                  tal:define="text python:view.strip_text(item);
@@ -141,7 +143,7 @@
                  tal:omit-tag="not:author">
                 Bob Dobalina
               </a> 
-              <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
+              <date tal:content="python: toLocalizedTime(item_display_date,long_format=1)">Date</date>
             </div>
           </hgroup>
           <p tal:content="text">Blog Entry Text</p>

--- a/src/lmu/contenttypes/blog/browser/templates/listing_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/listing_view.pt
@@ -79,7 +79,7 @@
                    tal:define="item entry/getObject;
                                item_creator entry/Creator;
                                item_type entry/portal_type;
-                               item_modified entry/ModificationDate;
+                               item_effective entry/EffectiveDate;
                                item_url item/getURL|item/absolute_url;
                                member python:view.get_memberdata(item);
                                text python:view.strip_text(item);
@@ -124,7 +124,7 @@
                    tal:omit-tag="not:author">
                   Bob Dobalina
                 </a> 
-                <date tal:content="python: toLocalizedTime(item_modified,long_format=1)">Date</date>
+                <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
               </div>
             </hgroup>
 

--- a/src/lmu/contenttypes/blog/browser/templates/listing_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/listing_view.pt
@@ -78,8 +78,10 @@
           <article class="blog-entry blog-preview tileItem visualIEFloatFix clearfix" 
                    tal:define="item entry/getObject;
                                item_creator entry/Creator;
+                               item_created entry/CreationDate;
                                item_type entry/portal_type;
                                item_effective entry/EffectiveDate;
+                               item_display_date python: item_effective != 'None' and item_effective or item_created;
                                item_url item/getURL|item/absolute_url;
                                member python:view.get_memberdata(item);
                                text python:view.strip_text(item);
@@ -124,7 +126,7 @@
                    tal:omit-tag="not:author">
                   Bob Dobalina
                 </a> 
-                <date tal:content="python: toLocalizedTime(item_effective,long_format=1)">Date</date>
+                <date tal:content="python: toLocalizedTime(item_display_date,long_format=1)">Date</date>
               </div>
             </hgroup>
 

--- a/src/lmu/contenttypes/blog/browser/views.py
+++ b/src/lmu/contenttypes/blog/browser/views.py
@@ -126,7 +126,7 @@ class _AbstractBlogListingView(_AbstractBlogView):
 
             entries = self.pcatalog.searchResults(
                 self.content_filter,
-                sort_on='modified', sort_order='reverse',
+                sort_on='effective', sort_order='reverse',
                 b_size=int(self.b_size),
                 b_start=int(self.b_start)
             )


### PR DESCRIPTION
Wenn kein Effective Date verfügbar ist (noch nicht publiziert) wird gar kein Datum angezeigt. Ist das OK oder soll es irgend ein Fallback geben?
