### PR TITLE
Fix rewriting scales

### DIFF
--- a/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
+++ b/src/lmu/contenttypes/blog/browser/templates/entry_view.pt
@@ -151,20 +151,23 @@
 
         <div class="row">
           <div class="columns small-12 medium-8"
-               tal:define="files view/files;"
+               tal:define="
+                 files view/files;
+                 images view/images;
+                 videos view/videos;
+                 show_first_image python: images and not videos;
+                 first_image python:show_first_image and images[0];
+                 other_images python: images[1:] if show_first_image else images;
+               "
                tal:attributes="class python: files and 'columns small-12 medium-8 end' or 'columns small-12 medium-8'" >
-            <div class="blog-video helper-margin-bottom-m" tal:condition="view/videos"  >
-              <video width="100%" height="auto" controls="controls" tal:repeat="video view/videos" >
+            <div class="blog-video helper-margin-bottom-m" tal:condition="videos"  >
+              <video width="100%" height="auto" controls="controls" tal:repeat="video videos" >
                 <source tal:attributes="src python:video.id;
                                         type: python:video.file.contentType" />
               </video>
             </div>
-            <div tal:condition="view/images" class="blog-images"
-                 tal:define="images view/images;
-                             videos view/videos;
-                             show_first_image python: images and not videos;">
-              <tal:first_image tal:define="first_image python: images[0];"
-                               tal:condition="show_first_image" >
+            <div tal:condition="images" class="blog-images">
+              <tal:first_image tal:condition="nocall:first_image" >
                 <a tal:attributes="href string:${first_image/absolute_url}/@@images/image.jpeg;" >
                   <figure  class="blog-lead-image helper-margin-bottom-m text-left"
                            tal:define="scales first_image/@@images;
@@ -180,17 +183,12 @@
                 </a>
               </tal:first_image>
               <ul class="clearing-thumbs clearing-feature small-block-grid-3 medium-block-grid-4 large-block-grid-6 helper-border-bottom helper-margin-bottom-l helper-no-margin-right"
-                  tal:condition="show"
-                  tal:define="images view/images;
-                              videos view/videos;
-                              length python: len(images);
-                              show python: length > 1 or (length > 0 and videos);"
+                  tal:condition="other_images"
                   data-clearing >
-                <tal:block tal:repeat="image view/images" >
+                <tal:block tal:repeat="image other_images" >
                   <li class="helper-no-padding-left clearing-featured-img"
-                      tal:define="first repeat/image/start;
-                                  show_first python:bool(videos) or not first;"
-                      tal:attributes="class python: 'helper-no-padding-left clearing-featured-img' if show_first else 'helper-no-padding-left';">
+                      tal:define="first repeat/image/start"
+                      tal:attributes="class python: 'helper-no-padding-left clearing-featured-img' if first else 'helper-no-padding-left';">
                     <a class="th" role="button" aria-label="Thumbnails"
                        tal:define="scales image/@@images;"
                        tal:attributes="href string:${image/absolute_url}/@@images/image.jpeg;">


### PR DESCRIPTION
If both the `entry_teaser` and the `listing_thumb` images are missing,
creating them rewrites all the content of 'plone.scale' in the
__annotations__.
For this reason when `entry_teaser` is created it has a valid URL that
will turn into a 404 as soon as the `listing_thumb` scale is created.

The patch avoids that and also simplifies the tal:condition statements.